### PR TITLE
refactor: consume reusable workflows from new github-actions-reusable-workflows repo

### DIFF
--- a/.github/workflows/check-community-approval.yaml
+++ b/.github/workflows/check-community-approval.yaml
@@ -1,5 +1,4 @@
 name: Check Community Approval
-
 on:
   pull_request:
     types:
@@ -13,14 +12,6 @@ permissions:
   contents: read
 
 jobs:
-  check_approval:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check for community approval
-        run: |
-          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'community-approved') }}" == "true" ]]; then
-            echo "This PR has met the requirements for community approval."
-          else
-            echo "::error::This PR has not met the requirements for community approval."
-            exit 1
-          fi
+  check-community-approval:
+    uses: mindbuttergold/github-actions-reusable-workflows/.github/workflows/check-community-approval.yaml@convert_reusable_workflows
+    secrets: inherit

--- a/.github/workflows/check-community-approval.yaml
+++ b/.github/workflows/check-community-approval.yaml
@@ -8,9 +8,6 @@ on:
       - labeled
       - unlabeled
 
-permissions:
-  contents: read
-
 jobs:
   check-community-approval:
     uses: mindbuttergold/github-actions-reusable-workflows/.github/workflows/check-community-approval.yaml@convert_reusable_workflows

--- a/.github/workflows/check-community-approval.yaml
+++ b/.github/workflows/check-community-approval.yaml
@@ -8,6 +8,9 @@ on:
       - labeled
       - unlabeled
 
+permissions:
+  contents: read
+
 jobs:
   check-community-approval:
     uses: mindbuttergold/github-actions-reusable-workflows/.github/workflows/check-community-approval.yaml@convert_reusable_workflows

--- a/.github/workflows/check-community-approval.yaml
+++ b/.github/workflows/check-community-approval.yaml
@@ -8,10 +8,9 @@ on:
       - labeled
       - unlabeled
 
-permissions:
-  contents: read
-
 jobs:
   check-community-approval:
+    permissions:
+      contents: read
     uses: mindbuttergold/github-actions-reusable-workflows/.github/workflows/check-community-approval.yaml@convert_reusable_workflows
     secrets: inherit

--- a/.github/workflows/check-community-approval.yaml
+++ b/.github/workflows/check-community-approval.yaml
@@ -1,4 +1,4 @@
-name: Check Community Approval
+name: check-community-approval
 on:
   pull_request:
     types:
@@ -7,10 +7,10 @@ on:
       - reopened
       - labeled
       - unlabeled
+permissions: read-all
 
 jobs:
   check-community-approval:
-    permissions:
-      contents: read
-    uses: mindbuttergold/github-actions-reusable-workflows/.github/workflows/check-community-approval.yaml@convert_reusable_workflows
+    name: check-community-approval
+    uses: mindbuttergold/github-actions-reusable-workflows/.github/workflows/check-community-approval.yaml@v1.0.0
     secrets: inherit

--- a/.github/workflows/check-pr-thumbs-up.yaml
+++ b/.github/workflows/check-pr-thumbs-up.yaml
@@ -1,16 +1,9 @@
 name: Check PR Thumbs Up and Manage Labels
 on:
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - labeled
-      - unlabeled
-  # schedule:
-  #   - cron: '0 5 * * *'   # Runs daily at 10:00 PM MST (5:00 AM UTC next day)
-  #   - cron: '0 13 * * *'  # Runs daily at 6:00 AM MST (1:00 PM UTC)  
-  #   - cron: '0 19 * * *'  # Runs daily at 12:00 PM MST (7:00 PM UTC)
+  schedule:
+    - cron: '0 5 * * *'   # Runs daily at 10:00 PM MST (5:00 AM UTC next day)
+    - cron: '0 13 * * *'  # Runs daily at 6:00 AM MST (1:00 PM UTC)  
+    - cron: '0 19 * * *'  # Runs daily at 12:00 PM MST (7:00 PM UTC)
 
 permissions:
   contents: read

--- a/.github/workflows/check-pr-thumbs-up.yaml
+++ b/.github/workflows/check-pr-thumbs-up.yaml
@@ -1,9 +1,16 @@
 name: Check PR Thumbs Up and Manage Labels
 on:
-  schedule:
-    - cron: '0 5 * * *'   # Runs daily at 10:00 PM MST (5:00 AM UTC next day)
-    - cron: '0 13 * * *'  # Runs daily at 6:00 AM MST (1:00 PM UTC)  
-    - cron: '0 19 * * *'  # Runs daily at 12:00 PM MST (7:00 PM UTC)
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+  # schedule:
+  #   - cron: '0 5 * * *'   # Runs daily at 10:00 PM MST (5:00 AM UTC next day)
+  #   - cron: '0 13 * * *'  # Runs daily at 6:00 AM MST (1:00 PM UTC)  
+  #   - cron: '0 19 * * *'  # Runs daily at 12:00 PM MST (7:00 PM UTC)
 
 permissions:
   contents: read

--- a/.github/workflows/check-pr-thumbs-up.yaml
+++ b/.github/workflows/check-pr-thumbs-up.yaml
@@ -1,13 +1,13 @@
-name: Check PR Thumbs Up and Manage Labels
+name: check-pr-thumbs-up
 on:
   schedule:
     - cron: '0 5 * * *'   # Runs daily at 10:00 PM MST (5:00 AM UTC next day)
     - cron: '0 13 * * *'  # Runs daily at 6:00 AM MST (1:00 PM UTC)  
     - cron: '0 19 * * *'  # Runs daily at 12:00 PM MST (7:00 PM UTC)
+permissions: read-all
 
 jobs:
   check-pr-thumbs-up:
-    permissions:
-      contents: read
-    uses: mindbuttergold/github-actions-reusable-workflows/.github/workflows/check-pr-thumbs-up.yaml@convert_reusable_workflows
+    name: check-pr-thumbs-up
+    uses: mindbuttergold/github-actions-reusable-workflows/.github/workflows/check-pr-thumbs-up.yaml@v1.0.0
     secrets: inherit

--- a/.github/workflows/check-pr-thumbs-up.yaml
+++ b/.github/workflows/check-pr-thumbs-up.yaml
@@ -1,5 +1,4 @@
 name: Check PR Thumbs Up and Manage Labels
-
 on:
   schedule:
     - cron: '0 5 * * *'   # Runs daily at 10:00 PM MST (5:00 AM UTC next day)
@@ -11,68 +10,5 @@ permissions:
 
 jobs:
   check-pr-thumbs-up:
-    runs-on: ubuntu-latest
-    env:
-      GH_TOKEN: ${{ secrets.LABEL_PRS_TOKEN }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-
-      - name: Get Open PR numbers
-        id: get-open-prs
-        run: |
-          OPEN_PR_NUMS=$(gh api "/repos/${GITHUB_REPOSITORY}/pulls?state=open" -q '.[].number' | tr '\n' ' ' | sed 's/[[:space:]]*$//')
-
-          if [ -z "$OPEN_PR_NUMS" ]; then
-            echo "No open PRs found."
-            exit 0
-          fi
-
-          echo "The following PR numbers are open: $OPEN_PR_NUMS"
-          echo "OPEN_PR_NUMS=$OPEN_PR_NUMS" >> $GITHUB_ENV
-          echo "open_prs=true" >> $GITHUB_OUTPUT
-
-      - name: Get PR Thumbs Up Counts and Manage Labels
-        if: steps.get-open-prs.outputs.open_prs == 'true'
-        run: |
-          OPEN_PR_NUMS="${{ env.OPEN_PR_NUMS }}"
-          eval "set -- $OPEN_PR_NUMS"
-
-          for PR_NUMBER in "$@"; do
-
-            PR_AUTHOR=$(gh api repos/${GITHUB_REPOSITORY}/pulls/$PR_NUMBER --jq '.user.login')
-            
-            THUMBS_UP_COUNT_EXCLUDING_AUTHOR=$(gh api \
-              -H "Accept: application/vnd.github+json" \
-              -H "X-GitHub-Api-Version: 2022-11-28" \
-              "/repos/${GITHUB_REPOSITORY}/issues/$PR_NUMBER/reactions" \
-              -q "[.[] | select(.content == \"+1\" and .user.login != \"$PR_AUTHOR\")] | length")   
-            echo "PR #$PR_NUMBER has $THUMBS_UP_COUNT_EXCLUDING_AUTHOR thumbs up excluding from the author."
-
-            if [ "$THUMBS_UP_COUNT_EXCLUDING_AUTHOR" -ge 5 ]; then
-              echo "Adding 'community-approved' label to PR #$PR_NUMBER."
-              gh api -X POST \
-                -H "Accept: application/vnd.github+json" \
-                -H "X-GitHub-Api-Version: 2022-11-28" \
-                "/repos/${GITHUB_REPOSITORY}/issues/$PR_NUMBER/labels" \
-                -f "labels[]=community-approved" > /dev/null
-            
-            else
-              echo "PR #$PR_NUMBER does not have enough thumbs up reactions."
-
-              HAS_COMMUNITY_APPROVED_LABEL=$(gh api \
-                -H "Accept: application/vnd.github+json" \
-                -H "X-GitHub-Api-Version: 2022-11-28" \
-                "/repos/${GITHUB_REPOSITORY}/issues/$PR_NUMBER/labels" \
-                -q '[.[] | select(.name == "community-approved")] | length')
-              
-              if [ "$HAS_COMMUNITY_APPROVED_LABEL" -gt 0 ]; then
-                echo "PR #$PR_NUMBER has the 'community-approved' label."
-                echo "Removing 'community-approved' label from PR #$PR_NUMBER."
-                gh api -X DELETE \
-                  -H "Accept: application/vnd.github+json" \
-                  -H "X-GitHub-Api-Version: 2022-11-28" \
-                  "/repos/${GITHUB_REPOSITORY}/issues/$PR_NUMBER/labels/community-approved" > /dev/null
-              fi
-            fi
-          done
+    uses: mindbuttergold/github-actions-reusable-workflows/.github/workflows/check-pr-thumbs-up.yaml@convert_reusable_workflows
+    secrets: inherit

--- a/.github/workflows/check-pr-thumbs-up.yaml
+++ b/.github/workflows/check-pr-thumbs-up.yaml
@@ -1,12 +1,16 @@
 name: Check PR Thumbs Up and Manage Labels
 on:
-  schedule:
-    - cron: '0 5 * * *'   # Runs daily at 10:00 PM MST (5:00 AM UTC next day)
-    - cron: '0 13 * * *'  # Runs daily at 6:00 AM MST (1:00 PM UTC)  
-    - cron: '0 19 * * *'  # Runs daily at 12:00 PM MST (7:00 PM UTC)
-
-permissions:
-  contents: read
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+  # schedule:
+  #   - cron: '0 5 * * *'   # Runs daily at 10:00 PM MST (5:00 AM UTC next day)
+  #   - cron: '0 13 * * *'  # Runs daily at 6:00 AM MST (1:00 PM UTC)  
+  #   - cron: '0 19 * * *'  # Runs daily at 12:00 PM MST (7:00 PM UTC)
 
 jobs:
   check-pr-thumbs-up:

--- a/.github/workflows/check-pr-thumbs-up.yaml
+++ b/.github/workflows/check-pr-thumbs-up.yaml
@@ -5,10 +5,9 @@ on:
     - cron: '0 13 * * *'  # Runs daily at 6:00 AM MST (1:00 PM UTC)  
     - cron: '0 19 * * *'  # Runs daily at 12:00 PM MST (7:00 PM UTC)
 
-permissions:
-  contents: read
-
 jobs:
   check-pr-thumbs-up:
+    permissions:
+      contents: read
     uses: mindbuttergold/github-actions-reusable-workflows/.github/workflows/check-pr-thumbs-up.yaml@convert_reusable_workflows
     secrets: inherit

--- a/.github/workflows/check-pr-thumbs-up.yaml
+++ b/.github/workflows/check-pr-thumbs-up.yaml
@@ -12,6 +12,9 @@ on:
   #   - cron: '0 13 * * *'  # Runs daily at 6:00 AM MST (1:00 PM UTC)  
   #   - cron: '0 19 * * *'  # Runs daily at 12:00 PM MST (7:00 PM UTC)
 
+permissions:
+  contents: read
+
 jobs:
   check-pr-thumbs-up:
     uses: mindbuttergold/github-actions-reusable-workflows/.github/workflows/check-pr-thumbs-up.yaml@convert_reusable_workflows

--- a/.github/workflows/ossf-scorecard.yaml
+++ b/.github/workflows/ossf-scorecard.yaml
@@ -12,6 +12,8 @@ on:
   # push:
   #   branches: [ "main" ]
 
+permissions: read-all
+
 jobs:
   analysis:
     uses: mindbuttergold/github-actions-reusable-workflows/.github/workflows/ossf-scorecard.yaml@convert_reusable_workflows

--- a/.github/workflows/ossf-scorecard.yaml
+++ b/.github/workflows/ossf-scorecard.yaml
@@ -1,30 +1,18 @@
 name: OSSF Scorecard
 on:
-  schedule:
-    - cron: '0 5 * * 1' # Every Sunday at 10pm MST (5:00 UTC)
-  push:
-    branches: [ "main" ]
-
-permissions: read-all
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+  # schedule:
+  #   - cron: '0 5 * * 1' # Every Sunday at 10pm MST (5:00 UTC)
+  # push:
+  #   branches: [ "main" ]
 
 jobs:
   analysis:
-    name: Scorecard analysis
-    runs-on: ubuntu-latest
-    permissions:
-      security-events: write
-      id-token: write
-
-    steps:
-      - name: "Checkout code"
-        uses: actions/checkout@v5
-        with:
-          persist-credentials: false
-
-      - name: "Run analysis"
-        uses: ossf/scorecard-action@v2.4.2
-        with:
-          results_file: results.sarif
-          results_format: sarif
-          repo_token: ${{ secrets.OSSF_SCORECARD_TOKEN }}
-          publish_results: true
+    uses: mindbuttergold/github-actions-reusable-workflows/.github/workflows/ossf-scorecard.yaml@convert_reusable_workflows
+    secrets: inherit

--- a/.github/workflows/ossf-scorecard.yaml
+++ b/.github/workflows/ossf-scorecard.yaml
@@ -1,16 +1,9 @@
 name: OSSF Scorecard
 on:
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - labeled
-      - unlabeled
-  # schedule:
-  #   - cron: '0 5 * * 1' # Every Sunday at 10pm MST (5:00 UTC)
-  # push:
-  #   branches: [ "main" ]
+  schedule:
+    - cron: '0 5 * * 1' # Every Sunday at 10pm MST (5:00 UTC)
+  push:
+    branches: [ "main" ]
 
 jobs:
   analysis:

--- a/.github/workflows/ossf-scorecard.yaml
+++ b/.github/workflows/ossf-scorecard.yaml
@@ -12,9 +12,10 @@ on:
   # push:
   #   branches: [ "main" ]
 
-permissions: read-all
-
 jobs:
   analysis:
+    permissions:
+      security-events: write
+      id-token: write
     uses: mindbuttergold/github-actions-reusable-workflows/.github/workflows/ossf-scorecard.yaml@convert_reusable_workflows
     secrets: inherit

--- a/.github/workflows/ossf-scorecard.yaml
+++ b/.github/workflows/ossf-scorecard.yaml
@@ -1,14 +1,16 @@
-name: OSSF Scorecard
+name: ossf-scorecard
 on:
   schedule:
     - cron: '0 5 * * 1' # Every Sunday at 10pm MST (5:00 UTC)
   push:
     branches: [ "main" ]
+permissions: read-all
 
 jobs:
-  analysis:
+  ossf-scorecard:
+    name: ossf-scorecard
     permissions:
       security-events: write
       id-token: write
-    uses: mindbuttergold/github-actions-reusable-workflows/.github/workflows/ossf-scorecard.yaml@convert_reusable_workflows
+    uses: mindbuttergold/github-actions-reusable-workflows/.github/workflows/ossf-scorecard.yaml@v1.0.0
     secrets: inherit

--- a/.github/workflows/semver-release.yaml
+++ b/.github/workflows/semver-release.yaml
@@ -4,9 +4,6 @@ on:
     branches:
       - main
 
-permissions:
-  contents: read
-
 jobs:
   release:
     permissions:

--- a/.github/workflows/semver-release.yaml
+++ b/.github/workflows/semver-release.yaml
@@ -1,15 +1,17 @@
-name: Semver Release
+name: semver-release
 on:
   push:
     branches:
       - main
+permissions: read-all
 
 jobs:
-  release:
+  semver-release:
+    name: semver-release
     permissions:
       contents: write
       issues: write
       pull-requests: write
       id-token: write
-    uses: mindbuttergold/github-actions-reusable-workflows/.github/workflows/semver-release.yaml@convert_reusable_workflows
+    uses: mindbuttergold/github-actions-reusable-workflows/.github/workflows/semver-release.yaml@v1.0.0
     secrets: inherit

--- a/.github/workflows/semver-release.yaml
+++ b/.github/workflows/semver-release.yaml
@@ -9,30 +9,10 @@ permissions:
 
 jobs:
   release:
-    name: Release
-    runs-on: ubuntu-latest
-
     permissions:
       contents: write
       issues: write
       pull-requests: write
       id-token: write
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "lts/*"
-
-      - name: Install Conventional Commits Preset Dependency
-        run: npm i conventional-changelog-conventionalcommits@v9 -D
-
-      - name: Release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npx semantic-release@24
+    uses: mindbuttergold/github-actions-reusable-workflows/.github/workflows/semver-release.yaml@convert_reusable_workflows
+    secrets: inherit

--- a/.github/workflows/validate-pr-title.yaml
+++ b/.github/workflows/validate-pr-title.yaml
@@ -1,5 +1,4 @@
 name: "Validate PR Title"
-
 on:
   pull_request_target:
     types:
@@ -8,15 +7,9 @@ on:
       - edited
       - reopened
 
-permissions:
-  contents: read
-
 jobs:
   validate_pr_title:
-    runs-on: ubuntu-latest
     permissions:
       pull-requests: read
-    steps:
-      - uses: amannn/action-semantic-pull-request@v5
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: mindbuttergold/github-actions-reusable-workflows/.github/workflows/validate-pr-title.yaml@convert_reusable_workflows
+    secrets: inherit

--- a/.github/workflows/validate-pr-title.yaml
+++ b/.github/workflows/validate-pr-title.yaml
@@ -1,4 +1,4 @@
-name: "Validate PR Title"
+name: validate-pr-title
 on:
   pull_request_target:
     types:
@@ -6,10 +6,12 @@ on:
       - synchronize
       - edited
       - reopened
+permissions: read-all
 
 jobs:
-  validate_pr_title:
+  validate-pr-title:
+    name: validate-pr-title
     permissions:
       pull-requests: read
-    uses: mindbuttergold/github-actions-reusable-workflows/.github/workflows/validate-pr-title.yaml@convert_reusable_workflows
+    uses: mindbuttergold/github-actions-reusable-workflows/.github/workflows/validate-pr-title.yaml@v1.0.0
     secrets: inherit


### PR DESCRIPTION
## What is the Feature / Change Being Made?

Instead of repeating the full workflows across repos, have repos consume the new reusable workflows from github-actions-reusable-workflows repo.

## What is the Rationale in Relation to Best Practices?

This keeps code DRYer, allowing updates to common workflows in the centralized place instead of having to update each repo's workflow individually, can just update the version if / when needed.

## How Has This Been Tested?

Testing through this PR by pointing to the reusable workflows in `github-actions-reusable-workflows` on a feature branch to ensure they're working properly.

## How Can the Community Use This?

The reusable workflows can be used by calling them in a github workflow job with `mindbuttergold/github-actions-reusable-workflows/.github/workflows/<workflow_file_name>.yaml@<version>`

## Links to Related Issues or Discussions

https://github.com/mindbuttergold/aws-multi-account/pull/1#discussion_r2148665328 @BA-CalderonMorales brought up discussion on a previous PR in an org repo about reusability of workflows.

### Contribution Reminders

Your PR needs:
- At least 5 thumbs up from members of the community to be approved / merged
- Final review / approval from at least one maintainer
- Clear, complete, and fully usable code for real-world systems
- No placeholder, unfinished, or copied code with incompatible licensing
- No redundant comments or unrelated artifacts
- The PR title to follow conventional commit standards

Refer the CONTRIBUTING guidelines and CODE_OF_CONDUCT for more information.
